### PR TITLE
Fix readme generation in build-homepage

### DIFF
--- a/build-homepage.sh
+++ b/build-homepage.sh
@@ -5,7 +5,8 @@ echo "Generating the README.md"
 cat templates/README-header.md > README.md
 echo "" >> README.md
 
-for file in "$(find ./crew -type f)"; do
+find ./crew -type f -print0 | while read -d $'\0' file
+do
   echo "Adding the member: ${file}"
   cat "${file}" >> README.md
   echo -e "---\n" >> README.md


### PR DESCRIPTION
Quoting the `find` in for can make bash not split on newline and give
an error like below. This should fix that. Also switched to a while
loop with -print0 so as to handle file names with spaces.

```
Generating the README.md
Adding the member: ./crew/jane-doe.md
./crew/meain.md
cat: './crew/jane-doe.md'$'\n''./crew/meain.md': No such file or directory
All crew members are updated!
```

Signed-off-by: Abin Simon <mail@meain.io>